### PR TITLE
[FEATURE] Add Turbo Action

### DIFF
--- a/source/funkin/input/Controls.hx
+++ b/source/funkin/input/Controls.hx
@@ -45,6 +45,10 @@ class Controls
 	public var UI_DOWN_P(get, never):Bool;
 	public var UI_UP_P(get, never):Bool;
 	public var UI_RIGHT_P(get, never):Bool;
+	public var UI_LEFT_T(get, never):Bool;
+	public var UI_DOWN_T(get, never):Bool;
+	public var UI_UP_T(get, never):Bool;
+	public var UI_RIGHT_T(get, never):Bool;
 	public var ACCEPT(get, never):Bool;
 	public var BACK(get, never):Bool;
 	public var PAUSE(get, never):Bool;
@@ -147,6 +151,30 @@ class Controls
 	inline function get_UI_RIGHT_P():Bool
 	{
 		return getAction(UIRight).checkPressed();
+	}
+
+	@:noCompletion
+	inline function get_UI_LEFT_T():Bool
+	{
+		return getAction(UILeft).checkTurbo();
+	}
+
+	@:noCompletion
+	inline function get_UI_DOWN_T():Bool
+	{
+		return getAction(UIDown).checkTurbo();
+	}
+
+	@:noCompletion
+	inline function get_UI_UP_T():Bool
+	{
+		return getAction(UIUp).checkTurbo();
+	}
+
+	@:noCompletion
+	inline function get_UI_RIGHT_T():Bool
+	{
+		return getAction(UIRight).checkTurbo();
 	}
 
 	@:noCompletion

--- a/source/funkin/input/FunkinAction.hx
+++ b/source/funkin/input/FunkinAction.hx
@@ -15,6 +15,10 @@ class FunkinAction
 
 	var timestamp(default, null):Int = -1;
 
+	var spamming:Bool = false;
+	var spamTicks:Int = 0;
+	var lastTicks:Int = -1;
+
 	public function new(keys:Array<FlxKey>, buttons:Array<GamepadButton>)
 	{
 		this.keys = keys;
@@ -36,6 +40,9 @@ class FunkinAction
 
 	public inline function checkPressed():Bool
 		return FlxG.game.ticks - timestamp <= FlxG.elapsed * Constants.MS_PER_SEC;
+
+	public inline function checkTurbo():Bool
+		return TurboControl.check(this);
 
 	public inline function hasKey(key:FlxKey):Bool
 		return keys.contains(key);

--- a/source/funkin/input/TurboControl.hx
+++ b/source/funkin/input/TurboControl.hx
@@ -1,0 +1,58 @@
+package funkin.input;
+
+@:access(funkin.input.FunkinAction)
+class TurboControl
+{
+	static var registry:Map<FunkinAction, TurboControl> = new Map<FunkinAction, TurboControl>();
+
+	public static function check(action:FunkinAction):Bool
+	{
+		var TurboControl:Null<TurboControl> = registry.get(action);
+
+		if (TurboControl == null)
+		{
+			TurboControl = new TurboControl(action);
+			registry.set(action, TurboControl);
+		}
+
+		return TurboControl?.active ?? false;
+	}
+
+	public var active:Bool = false;
+
+	var action:FunkinAction;
+
+	var spamming:Bool = false;
+	var spamTimer:Float = 0;
+
+	public function new(action:FunkinAction)
+	{
+		this.action = action;
+		FlxG.signals.preUpdate.add(() -> update(FlxG.elapsed));
+	}
+
+	function update(elapsed:Float):Void
+	{
+		active = false;
+
+		if (action.check())
+		{
+			if (spamming && spamTimer >= 0.07)
+			{
+				spamTimer = 0;
+				active = true;
+			}
+			else if (!spamming && spamTimer >= 0.5)
+				spamming = true;
+			else if (spamTimer <= 0)
+				active = true;
+
+			spamTimer += elapsed;
+		}
+		else
+		{
+			spamming = false;
+			spamTimer = 0;
+		}
+	}
+}

--- a/source/funkin/ui/freeplay/capsule/CapsuleGroup.hx
+++ b/source/funkin/ui/freeplay/capsule/CapsuleGroup.hx
@@ -37,8 +37,8 @@ class CapsuleGroup extends FlxTypedGroup<CapsuleSprite>
 	{
 		super.update(elapsed);
 
-		var up:Bool = Controls.instance.UI_UP_P;
-		var down:Bool = Controls.instance.UI_DOWN_P;
+		var up:Bool = Controls.instance.UI_UP_T;
+		var down:Bool = Controls.instance.UI_DOWN_T;
 
 		if ((up || down) && !busy)
 			change(up ? -1 : 1);

--- a/source/funkin/ui/options/OptionList.hx
+++ b/source/funkin/ui/options/OptionList.hx
@@ -33,10 +33,10 @@ class OptionList extends FlxTypedGroup<Option>
 	{
 		super.update(elapsed);
 
-		final up:Bool = controls.UI_UP_P;
-		final down:Bool = controls.UI_DOWN_P;
-		final left:Bool = controls.UI_LEFT_P;
-		final right:Bool = controls.UI_RIGHT_P;
+		final up:Bool = controls.UI_UP_T;
+		final down:Bool = controls.UI_DOWN_T;
+		final left:Bool = controls.UI_LEFT_T;
+		final right:Bool = controls.UI_RIGHT_T;
 		final accept:Bool = controls.ACCEPT;
 
 		if (up || down)

--- a/source/funkin/ui/story/TitleGroup.hx
+++ b/source/funkin/ui/story/TitleGroup.hx
@@ -55,8 +55,8 @@ class TitleGroup extends FlxTypedGroup<TitleText>
 	{
 		super.update(elapsed);
 
-		var up:Bool = Controls.instance.UI_UP_P;
-		var down:Bool = Controls.instance.UI_DOWN_P;
+		var up:Bool = Controls.instance.UI_UP_T;
+		var down:Bool = Controls.instance.UI_DOWN_T;
 
 		if ((up || down) && !busy)
 			change(up ? -1 : 1);


### PR DESCRIPTION
## What does this PR do?
This PR adds a turbo action to controls, which fires rapidly after being held for a certain amount of time. This is great for menus like Freeplay, where you don't want the user to spam down a button.